### PR TITLE
feat: enable npx support with bin and files fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ This server uses stdio transport, so it's compatible with MCP clients that launc
    {
      "mcpServers": {
        "flowbite-svelte": {
+         "command": "npx",
+         "args": ["-y", "flowbite-svelte-mcp"]
+       }
+     }
+   }
+   ```
+
+   Alternatively, if you have a local clone, you can reference the build directly:
+
+   ```json
+   {
+     "mcpServers": {
+       "flowbite-svelte": {
          "command": "node",
          "args": ["/ABSOLUTE/PATH/TO/flowbite-svelte-mcp/build/server.js"]
        }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "version": "0.3.2",
   "description": "MCP server for Flowbite-Svelte documentation (LLM)",
   "type": "module",
+  "bin": {
+    "flowbite-svelte-mcp": "./build/server.js"
+  },
+  "files": [
+    "build"
+  ],
   "engines": {
     "node": ">=20.0.0"
   },

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { McpServer } from 'tmcp';
 import { StdioTransport } from '@tmcp/transport-stdio';
 import { ZodJsonSchemaAdapter } from '@tmcp/adapter-zod';


### PR DESCRIPTION
## Summary

This PR makes the package executable via `npx flowbite-svelte-mcp`, enabling cross-platform MCP client configuration without hardcoded filesystem paths.

## Changes

1. **Added `bin` field** to `package.json` — tells npm/npx which file to execute
2. **Added `files` field** to `package.json` — ensures `build/` is included in the published npm tarball (currently excluded because `.gitignore` lists `build` and there's no `.npmignore`)

## Motivation

Currently, MCP clients must reference an absolute path to the built server:

```json
{
  "command": "node",
  "args": ["/ABSOLUTE/PATH/TO/flowbite-svelte-mcp/build/server.js"]
}
```

This is not portable across machines or operating systems. With these changes, after the next npm publish, clients can use:

```json
{
  "command": "npx",
  "args": ["-y", "flowbite-svelte-mcp"]
}
```

## Testing

- Verified `npm pack --dry-run` includes all `build/` files in the tarball
- Verified shebang is preserved in compiled `build/server.js`
- Verified `npm link` + `flowbite-svelte-mcp` binary starts and responds to MCP `initialize` handshake correctly

## Notes

- The existing `cp` publish script already runs `gen:registry && copy:llm && build` before `changeset publish`, so `build/` (including `build/data/`) will be fully populated at publish time.
- No changes to the build process or runtime behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package distribution configuration to include build artifacts for publishing.
  * Configured the application to be executable as a direct command-line tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->