### PR TITLE
fix: bypass waf block in copy:llm script and parallelize downloads

### DIFF
--- a/scripts/copyLlmData.ts
+++ b/scripts/copyLlmData.ts
@@ -13,7 +13,7 @@ import { promises as fs } from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { parseLlmsTxt, isValidFilePath } from '../src/lib/parser.js';
-import { LLMS_TXT_URL, LLM_DIR_URL } from '../src/lib/constants.js';
+import { GITHUB_RAW_LLMS_TXT_URL, GITHUB_RAW_LLM_DIR_URL } from '../src/lib/constants.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -26,9 +26,9 @@ const DEST_LLM_DIR = path.resolve(__dirname, '../src/data/llm');
  * @returns {Promise<string>} The raw content of llms.txt
  */
 async function fetchLlmsTxtContent(): Promise<string> {
-  const response = await fetch(LLMS_TXT_URL);
+  const response = await fetch(GITHUB_RAW_LLMS_TXT_URL);
   if (!response.ok) {
-    throw new Error(`Failed to fetch llms.txt: ${response.statusText}`);
+    throw new Error(`Failed to fetch llms.txt from GitHub: ${response.statusText}`);
   }
   return response.text();
 }
@@ -44,7 +44,7 @@ async function fetchAndSaveFile(relativePath: string): Promise<void> {
     throw new Error(`Invalid file path detected: ${relativePath}`);
   }
 
-  const url = `${LLM_DIR_URL}/${relativePath}`;
+  const url = `${GITHUB_RAW_LLM_DIR_URL}/${relativePath}`;
   const destPath = path.join(DEST_LLM_DIR, relativePath);
 
   // Create directory if needed
@@ -66,7 +66,7 @@ async function fetchAndSaveFile(relativePath: string): Promise<void> {
  */
 async function main() {
   try {
-    console.log('🚀 Starting LLM data download from flowbite-svelte.com...\n');
+    console.log('🚀 Starting LLM data download from GitHub Raw (Bypassing Cloudflare)...\n');
 
     // Clean destination directory
     console.log('🧹 Cleaning destination directory...');
@@ -90,6 +90,10 @@ async function main() {
     const files = parseLlmsTxt(llmsTxtContent);
     console.log(`  Found ${files.length} files to download`);
 
+    if (files.length === 0) {
+      throw new Error("No files parsed. Check llms.txt content or parseLlmsTxt logic.");
+    }
+
     // Validate all files before downloading
     const invalidFiles = files.filter(f => !isValidFilePath(f));
     if (invalidFiles.length > 0) {
@@ -98,17 +102,21 @@ async function main() {
       throw new Error('Security check failed: Invalid file paths found');
     }
 
-    // Download all files
+    // Download all files in parallel
     console.log('\n📂 Downloading documentation files...');
-    for (const file of files) {
-      await fetchAndSaveFile(file);
-    }
+    const downloadPromises = files.map(file => 
+      fetchAndSaveFile(file).catch(e => {
+        console.error(`  ❌ Error downloading ${file}: ${e.message}`);
+      })
+    );
+    
+    await Promise.all(downloadPromises);
 
     console.log('\n✅ Download completed successfully!');
     console.log(`   Files saved to: ${DEST_LLM_DIR}`);
     console.log(`   Total files: ${files.length + 1} (including llms.txt)`);
   } catch (error) {
-    console.error('❌ Download failed:', error);
+    console.error('\n❌ Download failed:', error);
     process.exit(1);
   }
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -16,3 +16,10 @@ export const LLMS_TXT_URL = `${BASE_URL}/llms.txt`;
  * Base URL for LLM documentation directory
  */
 export const LLM_DIR_URL = `${BASE_URL}/llm`;
+
+/**
+ * GitHub Raw URLs to bypass WAF protection during automated downloads.
+ * Used by the copy:llm script to fetch documentation directly from the source.
+ */
+export const GITHUB_RAW_LLMS_TXT_URL = 'https://raw.githubusercontent.com/themesberg/flowbite-svelte/main/static/llms.txt';
+export const GITHUB_RAW_LLM_DIR_URL = 'https://raw.githubusercontent.com/themesberg/flowbite-svelte/main/src/routes/llm';


### PR DESCRIPTION
## Description

Currently, running `npm run copy:llm` fails and downloads 0 files. Cloudflare's WAF on `flowbite-svelte.com` is intercepting the automated `fetch` requests, returning HTTP 429/403 or HTML challenges ("Verify you are human") instead of the actual Markdown text. This breaks the text parser and aborts the script. 

This PR fixes the issue by fetching the documentation directly from the Raw GitHub repository source.

## Changes Made

1. **Bypass Cloudflare via GitHub Raw**: 
   * Added `GITHUB_RAW_LLMS_TXT_URL` and `GITHUB_RAW_LLM_DIR` to `src/lib/constants.ts`.
   * The `copyLlmData.ts` script now uses these raw endpoints.
   * **Note:** The original `BASE_URL` constants remain completely untouched.

2. **Reused Native Parser**:
   * Kept the original `parseLlmsTxt` function. Since the `llms.txt` file hosted on GitHub still contains production URLs, the native parser works perfectly.

3. **Performance & Reliability (`Promise.all`)**:
   * Refactored the sequential `for...of` download loop into a parallel `Promise.all` execution. 
   * Since GitHub's raw CDN handles concurrent requests fine.
   * Added individual `.catch()` handlers to the download promises. If a single file fails to download, it no longer crashes the entire script, allowing the rest of the documentation to be fetched successfully.

## Testing

- [x] Ran `npm run copy:llm` successfully.
- [x] Verified that all 100+ files are downloaded into `src/data/llm`.
- [x] Verified that `llms.txt` is successfully downloaded and parsed.
- [x] Verified that the actual MCP server functions normally without being affected by the new constants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved documentation downloads for greater reliability.
  * Downloads now continue when individual documentation files fail.
  * Added clearer startup and failure messages.
  * Updated documentation sources to use direct raw-content URLs, helping automated downloads bypass web protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->